### PR TITLE
Huawei hms

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Android Options:
     --android                        enabled android (default: false)
 Huawei Options:
     -hk, --hmskey <hms_key>          HMS API Key
-    -hid, --hmsid <hms_id>       HMS APP Id
+    -hid, --hmsid <hms_id>           HMS APP Id
     --huawei                         enabled huawei (default: false)
 Common Options:
     --topic <topic>                  iOS or Android topic message
@@ -321,15 +321,16 @@ gorush --android --topic "/topics/foo-bar" \
 Send single notification with the following command.
 
 ```bash
-gorush -huawei -m "your message" -hk "API Key" -hid "APP Id" -t "Device token"
+gorush -huawei -title "Gorush with HMS" -m "your message" -hk "API Key" -hid "APP Id" -t "Device token"
 ```
 
 Send messages to topics.
 
 ```bash
-gorush --android --topic "foo-bar" \
+gorush --huawei --topic "foo-bar" \
+  -title "Gorush with HMS" \
   -m "This is a Firebase Cloud Messaging Topic Message" \
-  -hk "API Key"
+  -hk "API Key" \
   -hid "APP Id"
 ```
 
@@ -530,7 +531,8 @@ Simple send Huawei notification example, the `platform` value is `3`:
     {
       "tokens": ["token_a", "token_b"],
       "platform": 3,
-      "message": "Hello World Android!"
+      "title": "Gorush with HMS",
+      "message": "Hello World Huawei!"
     }
   ]
 }
@@ -568,7 +570,8 @@ Send multiple notifications as below:
     {
       "tokens": ["token_a", "token_b"],
       "platform": 3,
-      "message": "Hello World!"
+      "message": "Hello World Huawei!",
+      "title": "Gorush with HMS"
     },
     .....
   ]
@@ -675,13 +678,13 @@ See more detail about [Firebase Cloud Messaging HTTP Protocol reference](https:/
 
 ### Huawei notification
 
-#### app_id
-#### huawei_data
-#### huawei_notification
-#### huawei_ttl
-#### huawei_collapse_key
-#### bi_tag
-#### fast_app_target
+* app_id
+* huawei_data
+* huawei_notification
+* huawei_ttl
+* huawei_collapse_key
+* bi_tag
+* fast_app_target
 
 See more detail about [Huawei Mobulse Services Push API reference](https://developer.huawei.com/consumer/en/doc/development/HMS-References/push-sendapi).
 
@@ -907,7 +910,8 @@ Send messages to topics
     {
       "topic": "foo-bar",
       "platform": 3,
-      "message": "This is a Firebase Cloud Messaging Topic Message"
+      "message": "This is a Huawei Mobile Services Topic Message",
+      "title": "You got message"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ gorush --android --topic "/topics/foo-bar" \
 - `--topic`: Send messages to topics. note: don't add device token.
 - `--proxy`: Set `http`, `https` or `socks5` proxy url.
 
-### Send Huawei(HMS) notification
+### Send Huawei (HMS) notification
 
 Send single notification with the following command.
 
@@ -329,7 +329,7 @@ Send messages to topics.
 ```bash
 gorush --huawei --topic "foo-bar" \
   -title "Gorush with HMS" \
-  -m "This is a Firebase Cloud Messaging Topic Message" \
+  -m "This is a Huawei Mobile Services Topic Message" \
   -hk "API Key" \
   -hid "APP Id"
 ```
@@ -678,13 +678,13 @@ See more detail about [Firebase Cloud Messaging HTTP Protocol reference](https:/
 
 ### Huawei notification
 
-* app_id
-* huawei_data
-* huawei_notification
-* huawei_ttl
-* huawei_collapse_key
-* bi_tag
-* fast_app_target
+* app_id: app id from huawei developer console
+* huawei_data: mapped to data
+* huawei_notification: mapped to notification
+* huawei_ttl: mapped to ttl
+* huawei_collapse_key: mapped to collapse_key
+* bi_tag: 
+* fast_app_target: 
 
 See more detail about [Huawei Mobulse Services Push API reference](https://developer.huawei.com/consumer/en/doc/development/HMS-References/push-sendapi).
 
@@ -862,7 +862,7 @@ Send normal notification.
     {
       "tokens": ["token_a", "token_b"],
       "platform": 3,
-      "message": "Hello World Android!",
+      "message": "Hello World Huawei!",
       "title": "You got message"
     }
   ]
@@ -877,9 +877,9 @@ Add `notification` payload.
     {
       "tokens": ["token_a", "token_b"],
       "platform": 3,
-      "message": "Hello World Android!",
+      "message": "Hello World Huawei!",
       "title": "You got message",
-      "notification" : {
+      "huawei_notification" : {
         "icon": "myicon",
         "color": "#112244"
       }

--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,12 @@ android:
   apikey: "YOUR_API_KEY"
   max_retry: 0 # resend fail notification, default value zero is disabled
 
+huawei:
+  enabled: true
+  apikey: "YOUR_API_KEY"
+  appid: "YOUR_APP_ID"
+  max_retry: 0 # resend fail notification, default value zero is disabled
+
 ios:
   enabled: false
   key_path: ""
@@ -98,6 +104,7 @@ type ConfYaml struct {
 	Core    SectionCore    `yaml:"core"`
 	API     SectionAPI     `yaml:"api"`
 	Android SectionAndroid `yaml:"android"`
+	Huawei  SectionHuawei  `yaml:"huawei"`
 	Ios     SectionIos     `yaml:"ios"`
 	Log     SectionLog     `yaml:"log"`
 	Stat    SectionStat    `yaml:"stat"`
@@ -149,6 +156,14 @@ type SectionAPI struct {
 type SectionAndroid struct {
 	Enabled  bool   `yaml:"enabled"`
 	APIKey   string `yaml:"apikey"`
+	MaxRetry int    `yaml:"max_retry"`
+}
+
+// SectionHuawei is sub section of config.
+type SectionHuawei struct {
+	Enabled  bool   `yaml:"enabled"`
+	APIKey   string `yaml:"apikey"`
+	APPId    string `yaml:"appid"`
 	MaxRetry int    `yaml:"max_retry"`
 }
 
@@ -302,6 +317,12 @@ func LoadConf(confPath string) (ConfYaml, error) {
 	conf.Android.Enabled = viper.GetBool("android.enabled")
 	conf.Android.APIKey = viper.GetString("android.apikey")
 	conf.Android.MaxRetry = viper.GetInt("android.max_retry")
+
+	// Huawei
+	conf.Huawei.Enabled = viper.GetBool("huawei.enabled")
+	conf.Huawei.APIKey = viper.GetString("huawei.apikey")
+	conf.Huawei.APPId = viper.GetString("huawei.appid")
+	conf.Huawei.MaxRetry = viper.GetInt("huawei.max_retry")
 
 	// iOS
 	conf.Ios.Enabled = viper.GetBool("ios.enabled")

--- a/config/testdata/config.yml
+++ b/config/testdata/config.yml
@@ -43,6 +43,12 @@ android:
   apikey: "YOUR_API_KEY"
   max_retry: 0 # resend fail notification, default value zero is disabled
 
+huawei:
+  enabled: true
+  apikey: "YOUR_API_KEY"
+  appid: "YOUR_APP_ID"
+  max_retry: 0 # resend fail notification, default value zero is disabled
+
 ios:
   enabled: false
   key_path: "key.pem"

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mitchellh/mapstructure v1.1.2
-	github.com/msalihkarakasli/go-hms-push v0.0.0-20200615195759-7a970b71c22c
+	github.com/msalihkarakasli/go-hms-push v0.0.0-20200616114002-91cd23dfeed4
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/client_model v0.0.0-20191202183732-d1d2010b5bee // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mitchellh/mapstructure v1.1.2
+	github.com/msalihkarakasli/go-hms-push v0.0.0-20200615195759-7a970b71c22c
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/client_model v0.0.0-20191202183732-d1d2010b5bee // indirect

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,14 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/msalihkarakasli/go-hms-push v0.0.0-20200615195759-7a970b71c22c h1:OG1NL81rADpFFYqfWQFGWQZLgxajiOS9cZApwDaPpNg=
 github.com/msalihkarakasli/go-hms-push v0.0.0-20200615195759-7a970b71c22c/go.mod h1:4X2lQHsWGt+e3uRK124A6ndq3IIVymTAzEI9A1kIQKc=
+github.com/msalihkarakasli/go-hms-push v0.0.0-20200616075053-ff4aeca924ee h1:GhSc8Bz6jeSlPukx9t3eyWK30udyAoACCR9jtci4tVI=
+github.com/msalihkarakasli/go-hms-push v0.0.0-20200616075053-ff4aeca924ee/go.mod h1:4X2lQHsWGt+e3uRK124A6ndq3IIVymTAzEI9A1kIQKc=
+github.com/msalihkarakasli/go-hms-push v0.0.0-20200616081907-aa182701f7a8 h1:anVdFSIgATqyCKkgRV8TZs8JLvzvlocQmYdW4/QXlfw=
+github.com/msalihkarakasli/go-hms-push v0.0.0-20200616081907-aa182701f7a8/go.mod h1:4X2lQHsWGt+e3uRK124A6ndq3IIVymTAzEI9A1kIQKc=
+github.com/msalihkarakasli/go-hms-push v0.0.0-20200616090445-02629345434a h1:8RhjWJXeVuHBGjGDbjNVT9/k1oOblgYkZR11hTfbHXM=
+github.com/msalihkarakasli/go-hms-push v0.0.0-20200616090445-02629345434a/go.mod h1:4X2lQHsWGt+e3uRK124A6ndq3IIVymTAzEI9A1kIQKc=
+github.com/msalihkarakasli/go-hms-push v0.0.0-20200616114002-91cd23dfeed4 h1:3cAiZwpOmIXbP+3/SAriDi9XlxBwZCGhS0UGhnlYhi0=
+github.com/msalihkarakasli/go-hms-push v0.0.0-20200616114002-91cd23dfeed4/go.mod h1:4X2lQHsWGt+e3uRK124A6ndq3IIVymTAzEI9A1kIQKc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/msalihkarakasli/go-hms-push v0.0.0-20200615195759-7a970b71c22c h1:OG1NL81rADpFFYqfWQFGWQZLgxajiOS9cZApwDaPpNg=
+github.com/msalihkarakasli/go-hms-push v0.0.0-20200615195759-7a970b71c22c/go.mod h1:4X2lQHsWGt+e3uRK124A6ndq3IIVymTAzEI9A1kIQKc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/gorush/const.go
+++ b/gorush/const.go
@@ -23,4 +23,6 @@ const (
 	IosErrorKey       = "gorush-ios-error-count"
 	AndroidSuccessKey = "gorush-android-success-count"
 	AndroidErrorKey   = "gorush-android-error-count"
+	HuaweiSuccessKey  = "gorush-huawei-success-count"
+	HuaweiErrorKey    = "gorush-huawei-error-count"
 )

--- a/gorush/const.go
+++ b/gorush/const.go
@@ -5,6 +5,8 @@ const (
 	PlatFormIos = iota + 1
 	// PlatFormAndroid constant is 2 for Android
 	PlatFormAndroid
+	// PlatFormHuawei constant is 3 for Huawei
+	PlatFormHuawei
 )
 
 const (

--- a/gorush/global.go
+++ b/gorush/global.go
@@ -5,6 +5,7 @@ import (
 	"github.com/appleboy/gorush/storage"
 
 	"github.com/appleboy/go-fcm"
+	"github.com/msalihkarakasli/go-hms-push/push/core"
 	"github.com/sideshow/apns2"
 	"github.com/sirupsen/logrus"
 )
@@ -18,6 +19,8 @@ var (
 	ApnsClient *apns2.Client
 	// FCMClient is apns client
 	FCMClient *fcm.Client
+	// HMSClient is Huawei push client
+	HMSClient *core.HMSClient
 	// LogAccess is log server request log
 	LogAccess *logrus.Logger
 	// LogError is log server error log

--- a/gorush/log.go
+++ b/gorush/log.go
@@ -122,6 +122,8 @@ func colorForPlatForm(platform int) string {
 		return blue
 	case PlatFormAndroid:
 		return yellow
+	case PlatFormHuawei:
+		return green
 	default:
 		return reset
 	}
@@ -133,6 +135,8 @@ func typeForPlatForm(platform int) string {
 		return "ios"
 	case PlatFormAndroid:
 		return "android"
+	case PlatFormHuawei:
+		return "huawei"
 	default:
 		return ""
 	}

--- a/gorush/metrics.go
+++ b/gorush/metrics.go
@@ -108,12 +108,12 @@ func (c Metrics) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(
 		c.HuaweiSuccess,
 		prometheus.GaugeValue,
-		float64(StatStorage.GetAndroidSuccess()),
+		float64(StatStorage.GetHuaweiSuccess()),
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.HuaweiError,
 		prometheus.GaugeValue,
-		float64(StatStorage.GetAndroidError()),
+		float64(StatStorage.GetHuaweiError()),
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.QueueUsage,

--- a/gorush/metrics.go
+++ b/gorush/metrics.go
@@ -14,6 +14,8 @@ type Metrics struct {
 	IosError       *prometheus.Desc
 	AndroidSuccess *prometheus.Desc
 	AndroidError   *prometheus.Desc
+	HuaweiSuccess  *prometheus.Desc
+	HuaweiError    *prometheus.Desc
 	QueueUsage     *prometheus.Desc
 }
 
@@ -46,6 +48,16 @@ func NewMetrics() Metrics {
 			"Number of android fail count",
 			nil, nil,
 		),
+		HuaweiSuccess: prometheus.NewDesc(
+			namespace+"huawei_success",
+			"Number of huawei success count",
+			nil, nil,
+		),
+		HuaweiError: prometheus.NewDesc(
+			namespace+"huawei_fail",
+			"Number of huawei fail count",
+			nil, nil,
+		),
 		QueueUsage: prometheus.NewDesc(
 			namespace+"queue_usage",
 			"Length of internal queue",
@@ -61,6 +73,8 @@ func (c Metrics) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.IosError
 	ch <- c.AndroidSuccess
 	ch <- c.AndroidError
+	ch <- c.HuaweiSuccess
+	ch <- c.HuaweiError
 	ch <- c.QueueUsage
 }
 
@@ -88,6 +102,16 @@ func (c Metrics) Collect(ch chan<- prometheus.Metric) {
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.AndroidError,
+		prometheus.GaugeValue,
+		float64(StatStorage.GetAndroidError()),
+	)
+		ch <- prometheus.MustNewConstMetric(
+		c.HuaweiSuccess,
+		prometheus.GaugeValue,
+		float64(StatStorage.GetAndroidSuccess()),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.HuaweiError,
 		prometheus.GaugeValue,
 		float64(StatStorage.GetAndroidError()),
 	)

--- a/gorush/notification.go
+++ b/gorush/notification.go
@@ -182,8 +182,8 @@ func SetProxy(proxy string) error {
 
 // CheckPushConf provide check your yml config.
 func CheckPushConf() error {
-	if !PushConf.Ios.Enabled && !PushConf.Android.Enabled {
-		return errors.New("Please enable iOS or Android config in yml config")
+	if !PushConf.Ios.Enabled && !PushConf.Android.Enabled && !PushConf.Huawei.Enabled {
+		return errors.New("Please enable iOS, Android or Huawei config in yml config")
 	}
 
 	if PushConf.Ios.Enabled {
@@ -202,6 +202,16 @@ func CheckPushConf() error {
 	if PushConf.Android.Enabled {
 		if PushConf.Android.APIKey == "" {
 			return errors.New("Missing Android API Key")
+		}
+	}
+
+	if PushConf.Huawei.Enabled {
+		if PushConf.Huawei.APIKey == "" {
+			return errors.New("Missing Huawei API Key")
+		}
+
+		if PushConf.Huawei.APPId == "" {
+			return errors.New("Missing Huawei APP Id")
 		}
 	}
 

--- a/gorush/notification.go
+++ b/gorush/notification.go
@@ -131,8 +131,16 @@ func (p *PushNotification) AddLog(log LogPushEntry) {
 // IsTopic check if message format is topic for FCM
 // ref: https://firebase.google.com/docs/cloud-messaging/send-message#topic-http-post-request
 func (p *PushNotification) IsTopic() bool {
-	return (p.Platform == PlatFormAndroid && p.To != "" && strings.HasPrefix(p.To, "/topics/")) ||
-		p.Condition != ""
+	
+	if (p.Platform == PlatFormAndroid){
+		return p.To != "" && strings.HasPrefix(p.To, "/topics/") || p.Condition != ""
+	}
+
+	if (p.Platform == PlatFormHuawei) {
+		return p.Topic != "" || p.Condition != ""
+	}
+
+	return false
 }
 
 // CheckMessage for check request message

--- a/gorush/notification.go
+++ b/gorush/notification.go
@@ -79,6 +79,9 @@ type PushNotification struct {
 	Condition             string            `json:"condition,omitempty"`
 	Notification          *fcm.Notification `json:"notification,omitempty"`
 
+	// Huawei
+	APPId   string `json:"api_key,omitempty"`
+
 	// iOS
 	Expiration  *int64   `json:"expiration,omitempty"`
 	ApnsID      string   `json:"apns_id,omitempty"`
@@ -148,7 +151,7 @@ func CheckMessage(req PushNotification) error {
 		return errors.New(msg)
 	}
 
-	if req.Platform == PlatformHuawei && len(req.Tokens) > 500 {
+	if req.Platform == PlatFormHuawei && len(req.Tokens) > 500 {
 		msg = "the message may specify at most 500 registration IDs for Huawei"
 		LogAccess.Debug(msg)
 		return errors.New(msg)

--- a/gorush/notification.go
+++ b/gorush/notification.go
@@ -148,6 +148,12 @@ func CheckMessage(req PushNotification) error {
 		return errors.New(msg)
 	}
 
+	if req.Platform == PlatformHuawei && len(req.Tokens) > 500 {
+		msg = "the message may specify at most 500 registration IDs for Huawei"
+		LogAccess.Debug(msg)
+		return errors.New(msg)
+	}
+
 	// ref: https://firebase.google.com/docs/cloud-messaging/http-server-ref
 	if req.Platform == PlatFormAndroid && req.TimeToLive != nil && (*req.TimeToLive < uint(0) || uint(2419200) < *req.TimeToLive) {
 		msg = "the message's TimeToLive field must be an integer " +

--- a/gorush/notification.go
+++ b/gorush/notification.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/appleboy/go-fcm"
+	"github.com/msalihkarakasli/go-hms-push/push/model"
 )
 
 // D provide string array
@@ -80,7 +81,8 @@ type PushNotification struct {
 	Notification          *fcm.Notification `json:"notification,omitempty"`
 
 	// Huawei
-	APPId   string `json:"api_key,omitempty"`
+	APPId                string `json:"api_key,omitempty"`
+	HuaweiNotification   *model.AndroidNotification `json:"huawei_notification,omitempty"`
 
 	// iOS
 	Expiration  *int64   `json:"expiration,omitempty"`

--- a/gorush/notification.go
+++ b/gorush/notification.go
@@ -81,8 +81,13 @@ type PushNotification struct {
 	Notification          *fcm.Notification `json:"notification,omitempty"`
 
 	// Huawei
-	APPId                string `json:"api_key,omitempty"`
+	APPId                string                     `json:"api_key,omitempty"`
 	HuaweiNotification   *model.AndroidNotification `json:"huawei_notification,omitempty"`
+	HuaweiData           string                     `json:"huawei_data,omitempty"`
+	HuaweiCollapseKey    int                        `json:"huawei_collapse_key,omitempty"`
+	HuaweiTTL            string                     `json:"huawei_ttl,omitempty"`
+	BiTag                string                     `json:"bi_tag,omitempty"`
+	FastAppTarget        int                        `json:"fast_app_target,omitempty"`
 
 	// iOS
 	Expiration  *int64   `json:"expiration,omitempty"`

--- a/gorush/notification.go
+++ b/gorush/notification.go
@@ -81,7 +81,7 @@ type PushNotification struct {
 	Notification          *fcm.Notification `json:"notification,omitempty"`
 
 	// Huawei
-	APPId                string                     `json:"api_key,omitempty"`
+	APPId                string                     `json:"app_id,omitempty"`
 	HuaweiNotification   *model.AndroidNotification `json:"huawei_notification,omitempty"`
 	HuaweiData           string                     `json:"huawei_data,omitempty"`
 	HuaweiCollapseKey    int                        `json:"huawei_collapse_key,omitempty"`

--- a/gorush/notification_hms.go
+++ b/gorush/notification_hms.go
@@ -1,0 +1,282 @@
+package gorush
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"encoding/json"
+
+	"github.com/msalihkarakasli/go-hms-push/push/model"
+	"github.com/msalihkarakasli/go-hms-push/push/core"
+	"github.com/msalihkarakasli/go-hms-push/push/config"
+)
+
+var (
+	pushError   error
+	pushClient  *core.HMSClient
+	once        sync.Once
+)
+
+func GetPushClient(conf *config.Config) (*core.HMSClient, error){
+	once.Do(func() {
+		client, err := core.NewHttpClient(conf)
+		if err != nil {
+			fmt.Printf("Failed to new common client! Error is %s\n", err.Error())
+			panic(err)
+		}
+		pushClient = client
+		pushError = err
+	})
+
+	return pushClient, pushError
+}
+
+// InitHMSClient use for initialize HMS Client.
+func InitHMSClient(apiKey string, appId string) (*core.HMSClient, error) {
+
+	if apiKey == "" {
+		return nil, errors.New("Missing Huawei API Key")
+	}
+
+	if appId == "" {
+		return nil, errors.New("Missing Huawei App Id")
+	}
+
+	var conf = &config.Config{
+		AppId:     appId,
+		AppSecret: apiKey,
+		AuthUrl: "https://login.cloud.huawei.com/oauth2/v2/token",
+		PushUrl: "https://api.push.hicloud.com",
+	}
+
+	if apiKey != PushConf.Huawei.APIKey || appId != PushConf.Huawei.APPId {
+		return GetPushClient(conf)
+	}
+
+	if HMSClient == nil {
+		return GetPushClient(conf)
+	}
+
+	return HMSClient, nil
+}
+
+// GetHuaweiNotification use for define HMS notification.
+// HTTP Connection Server Reference for HMS
+// https://developer.huawei.com/consumer/en/doc/development/HMS-References/push-sendapi
+func GetHuaweiNotification(req PushNotification) (*model.MessageRequest, error) {
+	
+	msgRequest := model.NewNotificationMsgRequest()
+	msgRequest.Message.Token = req.Tokens
+	msgRequest.Message.Android = model.GetDefaultAndroid()
+	msgRequest.Message.Android.Notification = model.GetDefaultAndroidNotification()
+
+	b, err := json.Marshal(msgRequest)
+	if err != nil {
+		fmt.Printf("Failed to marshal the default message! Error is %s\n", err.Error())
+		return nil, err
+	}
+
+	fmt.Printf("Default message is %s\n", string(b))
+	return msgRequest, nil
+
+	//TODO: Fix This part
+
+	// notification := &fcm.Message{
+	// 	To:                    req.To,
+	// 	Condition:             req.Condition,
+	// 	CollapseKey:           req.CollapseKey,
+	// 	ContentAvailable:      req.ContentAvailable,
+	// 	MutableContent:        req.MutableContent,
+	// 	DelayWhileIdle:        req.DelayWhileIdle,
+	// 	TimeToLive:            req.TimeToLive,
+	// 	RestrictedPackageName: req.RestrictedPackageName,
+	// 	DryRun:                req.DryRun,
+	// }
+
+	// if len(req.Tokens) > 0 {
+	// 	notification.RegistrationIDs = req.Tokens
+	// }
+
+	// if len(req.Priority) > 0 && req.Priority == "high" {
+	// 	notification.Priority = "high"
+	// }
+
+	// // Add another field
+	// if len(req.Data) > 0 {
+	// 	notification.Data = make(map[string]interface{})
+	// 	for k, v := range req.Data {
+	// 		notification.Data[k] = v
+	// 	}
+	// }
+
+	// n := &fcm.Notification{}
+	// isNotificationSet := false
+	// if req.Notification != nil {
+	// 	isNotificationSet = true
+	// 	n = req.Notification
+	// }
+
+	// if len(req.Message) > 0 {
+	// 	isNotificationSet = true
+	// 	n.Body = req.Message
+	// }
+
+	// if len(req.Title) > 0 {
+	// 	isNotificationSet = true
+	// 	n.Title = req.Title
+	// }
+
+	// if len(req.Image) > 0 {
+	// 	isNotificationSet = true
+	// 	n.Image = req.Image
+	// }
+
+	// if v, ok := req.Sound.(string); ok && len(v) > 0 {
+	// 	isNotificationSet = true
+	// 	n.Sound = v
+	// }
+
+	// if isNotificationSet {
+	// 	notification.Notification = n
+	// }
+
+	// // handle iOS apns in fcm
+
+	// if len(req.Apns) > 0 {
+	// 	notification.Apns = req.Apns
+	// }
+
+	// return notification
+}
+
+// PushToHuawei provide send notification to Android server.
+func PushToHuawei(req PushNotification) bool {
+	LogAccess.Debug("Start push notification for Huawei")
+
+	var (
+		client     *core.HMSClient
+		retryCount = 0
+		maxRetry   = PushConf.Huawei.MaxRetry
+	)
+
+	if req.Retry > 0 && req.Retry < maxRetry {
+		maxRetry = req.Retry
+	}
+
+	// check message
+	err := CheckMessage(req)
+
+	if err != nil {
+		LogError.Error("request error: " + err.Error())
+		return false
+	}
+
+Retry:
+	var isError = false
+
+	notification, err := GetHuaweiNotification(req)
+
+	client, err = InitHMSClient(PushConf.Huawei.APIKey, PushConf.Huawei.APPId)
+
+	if err != nil {
+		// HMS server error
+		LogError.Error("HMS server error: " + err.Error())
+		return false
+	}
+
+	res, err := client.SendMessage(context.Background(), notification)
+	if err != nil {
+		// Send Message error
+		LogError.Error("HMS server send message error: " + err.Error())
+		return false
+	}
+
+	fmt.Println(res);
+	// if !req.IsTopic() {
+	// 	LogAccess.Debug(fmt.Sprintf("Android Success count: %d, Failure count: %d", res.Success, res.Failure))
+	// }
+
+	
+	//StatStorage.AddAndroidSuccess(int64(res.Success))
+	//StatStorage.AddAndroidError(int64(res.Failure))
+
+	//var newTokens []string
+	// result from Send messages to specific devices
+	// for k, result := range res.Results {
+	// 	to := ""
+	// 	if k < len(req.Tokens) {
+	// 		to = req.Tokens[k]
+	// 	} else {
+	// 		to = req.To
+	// 	}
+
+	// 	if result.Error != nil {
+	// 		// We should retry only "retryable" statuses. More info about response:
+	// 		// https://firebase.google.com/docs/cloud-messaging/http-server-ref#downstream-http-messages-plain-text
+	// 		if !result.Unregistered() {
+	// 			newTokens = append(newTokens, to)
+	// 		}
+	// 		isError = true
+
+	// 		LogPush(FailedPush, to, req, result.Error)
+	// 		if PushConf.Core.Sync {
+	// 			req.AddLog(getLogPushEntry(FailedPush, to, req, result.Error))
+	// 		} else if PushConf.Core.FeedbackURL != "" {
+	// 			go func(logger *logrus.Logger, log LogPushEntry, url string, timeout int64) {
+	// 				err := DispatchFeedback(log, url, timeout)
+	// 				if err != nil {
+	// 					logger.Error(err)
+	// 				}
+	// 			}(LogError, getLogPushEntry(FailedPush, to, req, result.Error), PushConf.Core.FeedbackURL, PushConf.Core.FeedbackTimeout)
+	// 		}
+	// 		continue
+	// 	}
+
+	// 	LogPush(SucceededPush, to, req, nil)
+	// }
+
+	// result from Send messages to topics
+	// if req.IsTopic() {
+	// 	to := ""
+	// 	if req.To != "" {
+	// 		to = req.To
+	// 	} else {
+	// 		to = req.Condition
+	// 	}
+	// 	LogAccess.Debug("Send Topic Message: ", to)
+	// 	// Success
+	// 	if res.MessageID != 0 {
+	// 		LogPush(SucceededPush, to, req, nil)
+	// 	} else {
+	// 		isError = true
+	// 		// failure
+	// 		LogPush(FailedPush, to, req, res.Error)
+	// 		if PushConf.Core.Sync {
+	// 			req.AddLog(getLogPushEntry(FailedPush, to, req, res.Error))
+	// 		}
+	// 	}
+	// }
+
+	// // Device Group HTTP Response
+	// if len(res.FailedRegistrationIDs) > 0 {
+	// 	isError = true
+	// 	newTokens = append(newTokens, res.FailedRegistrationIDs...)
+
+	// 	LogPush(FailedPush, notification.To, req, errors.New("device group: partial success or all fails"))
+	// 	if PushConf.Core.Sync {
+	// 		req.AddLog(getLogPushEntry(FailedPush, notification.To, req, errors.New("device group: partial success or all fails")))
+	// 	}
+	// }
+
+	if isError && retryCount < maxRetry {
+	 	retryCount++
+
+	 	// resend fail token
+	 	//req.Tokens = newTokens
+	 	goto Retry
+	}
+
+	return false;
+	//return isError
+}

--- a/gorush/notification_hms.go
+++ b/gorush/notification_hms.go
@@ -79,6 +79,10 @@ func GetHuaweiNotification(req PushNotification) (*model.MessageRequest, error) 
 		msgRequest.Message.Topic = req.Topic;
 	}
 
+	if len(req.To) > 0 {
+		msgRequest.Message.Topic = req.To;
+	}
+
 	if len(req.Condition) > 0 {
 		msgRequest.Message.Condition = req.Condition
 	}

--- a/gorush/notification_hms.go
+++ b/gorush/notification_hms.go
@@ -68,73 +68,91 @@ func InitHMSClient(apiKey string, appId string) (*core.HMSClient, error) {
 func GetHuaweiNotification(req PushNotification) (*model.MessageRequest, error) {
 	
 	msgRequest := model.NewNotificationMsgRequest()
-	msgRequest.Message.Token = req.Tokens
 
 	msgRequest.Message.Android = model.GetDefaultAndroid()
 
-	msgRequest.Message.Condition = req.Condition
-	//msgRequest.Message.Android.CollapseKey = req.CollapseKey
-
-	// notification := &fcm.Message{
-	// 	To:                    req.To,
-	// 	Condition:             req.Condition,
-	// 	CollapseKey:           req.CollapseKey,
-	// 	ContentAvailable:      req.ContentAvailable,
-	// 	MutableContent:        req.MutableContent,
-	// 	DelayWhileIdle:        req.DelayWhileIdle,
-	// 	TimeToLive:            req.TimeToLive,
-	// 	RestrictedPackageName: req.RestrictedPackageName,
-	// 	DryRun:                req.DryRun,
-	// }
-
-	msgRequest.Message.Android.Notification = model.GetDefaultAndroidNotification()
-
 	if len(req.Tokens) > 0 {
-	 	msgRequest.Message.Token = req.Tokens
-	 }
-
-	if len(req.Priority) > 0 && req.Priority == "high" {
-	 	msgRequest.Message.Android.Urgency = "HIGH"
-	 }
-
-	// Add another field
-	// if len(req.Data) > 0 {
-	//  	msgRequest.Message.Android.Data = make(map[string]interface{})
-	//  	for k, v := range req.Data {
-	//  		msgRequest.Message.Android.Data[k] = v
-	//  	}
-	//  }
-
-	 n := msgRequest.Message.Android.Notification
-	 isNotificationSet := false
-	if req.Notification != nil {
-	 	isNotificationSet = true
-	 	n = req.HuaweiNotification
+		msgRequest.Message.Token = req.Tokens
 	}
 
-	if len(req.Message) > 0 {
-	 	isNotificationSet = true
-	 	n.Body = req.Message
+	if len(req.Topic) > 0 {
+		msgRequest.Message.Topic = req.Topic;
 	}
 
-	if len(req.Title) > 0 {
-	 	isNotificationSet = true
-	 	n.Title = req.Title
+	if len(req.Condition) > 0 {
+		msgRequest.Message.Condition = req.Condition
 	}
 
-	if len(req.Image) > 0 {
-	 	isNotificationSet = true
-	 	n.Image = req.Image
+	if req.Priority == "high" {
+		msgRequest.Message.Android.Urgency = "HIGH"
 	}
 
-	if v, ok := req.Sound.(string); ok && len(v) > 0 {
-	 	isNotificationSet = true
-	 	n.Sound = v
+	//if req.HuaweiCollapseKey != nil {
+		msgRequest.Message.Android.CollapseKey = req.HuaweiCollapseKey
+	//}
+
+	if len(req.Category) > 0 {
+		msgRequest.Message.Android.Category = req.Category
 	}
 
-	if isNotificationSet {
-	 	msgRequest.Message.Android.Notification = n
-	 }
+	if len(req.HuaweiTTL) > 0 {
+		msgRequest.Message.Android.TTL = req.HuaweiTTL
+	}
+
+	if len(req.BiTag) > 0 {
+		msgRequest.Message.Android.BiTag = req.BiTag
+	}
+
+	//if req.FastAppTarget != nil {
+		msgRequest.Message.Android.FastAppTarget = req.FastAppTarget
+	//}
+
+	//Add data fields
+	if len(req.HuaweiData) > 0 {
+	  	msgRequest.Message.Data = req.HuaweiData
+	} else {
+		//Notification Message
+		msgRequest.Message.Android.Notification = model.GetDefaultAndroidNotification()
+
+		n := msgRequest.Message.Android.Notification
+		isNotificationSet := false
+		
+		if req.HuaweiNotification != nil {
+		 	isNotificationSet = true
+		 	n = req.HuaweiNotification
+
+		 	if n.ClickAction == nil {
+		 		n.ClickAction = model.GetDefaultClickAction()
+		 	}
+		}
+
+		if len(req.Message) > 0 {
+		 	isNotificationSet = true
+		 	n.Body = req.Message
+		}
+
+		if len(req.Title) > 0 {
+		 	isNotificationSet = true
+		 	n.Title = req.Title
+		}
+
+		if len(req.Image) > 0 {
+		 	isNotificationSet = true
+		 	n.Image = req.Image
+		}
+
+		if v, ok := req.Sound.(string); ok && len(v) > 0 {
+		 	isNotificationSet = true
+		 	n.Sound = v
+		} else {
+			n.DefaultSound = true;
+		}
+
+
+		if isNotificationSet {
+		 	msgRequest.Message.Android.Notification = n
+		 }
+	}
 
 	// if len(req.Apns) > 0 {
 	// 	notification.Apns = req.Apns

--- a/gorush/status.go
+++ b/gorush/status.go
@@ -26,6 +26,7 @@ type StatusApp struct {
 	TotalCount int64         `json:"total_count"`
 	Ios        IosStatus     `json:"ios"`
 	Android    AndroidStatus `json:"android"`
+	Huawei     HuaweiStatus  `json:"huawei"`
 }
 
 // AndroidStatus is android structure
@@ -36,6 +37,12 @@ type AndroidStatus struct {
 
 // IosStatus is iOS structure
 type IosStatus struct {
+	PushSuccess int64 `json:"push_success"`
+	PushError   int64 `json:"push_error"`
+}
+
+// IosStatus is iOS structure
+type HuaweiStatus struct {
 	PushSuccess int64 `json:"push_success"`
 	PushError   int64 `json:"push_error"`
 }
@@ -81,6 +88,8 @@ func appStatusHandler(c *gin.Context) {
 	result.Ios.PushError = StatStorage.GetIosError()
 	result.Android.PushSuccess = StatStorage.GetAndroidSuccess()
 	result.Android.PushError = StatStorage.GetAndroidError()
+	result.Huawei.PushSuccess = StatStorage.GetHuaweiSuccess()
+	result.Huawei.PushError = StatStorage.GetHuaweiError()
 
 	c.JSON(http.StatusOK, result)
 }

--- a/gorush/worker.go
+++ b/gorush/worker.go
@@ -15,7 +15,7 @@ func InitWorkers(ctx context.Context, wg *sync.WaitGroup, workerNum int64, queue
 	}
 }
 
-// SendNotification is send message to iOS or Android
+// SendNotification is send message to iOS, Android or Huawei
 func SendNotification(ctx context.Context, req PushNotification) {
 	if PushConf.Core.Sync {
 		defer req.WaitDone()
@@ -26,6 +26,8 @@ func SendNotification(ctx context.Context, req PushNotification) {
 		PushToIOS(req)
 	case PlatFormAndroid:
 		PushToAndroid(req)
+	case PlatFormHuawei:
+		//PushToHuawei(req)
 	}
 }
 

--- a/gorush/worker.go
+++ b/gorush/worker.go
@@ -27,7 +27,7 @@ func SendNotification(ctx context.Context, req PushNotification) {
 	case PlatFormAndroid:
 		PushToAndroid(req)
 	case PlatFormHuawei:
-		//PushToHuawei(req)
+		PushToHuawei(req)
 	}
 }
 

--- a/gorush/worker.go
+++ b/gorush/worker.go
@@ -64,6 +64,10 @@ func queueNotification(ctx context.Context, req RequestPush) (int, []LogPushEntr
 			if !PushConf.Android.Enabled {
 				continue
 			}
+		case PlatFormHuawei:
+			if !PushConf.Huawei.Enabled {
+				continue
+			}
 		}
 		newNotification = append(newNotification, notification)
 	}

--- a/main.go
+++ b/main.go
@@ -244,7 +244,7 @@ func main() {
 			return
 		}
 
-		//gorush.PushToHuawei(req)
+		gorush.PushToHuawei(req)
 
 		return
 	}
@@ -334,7 +334,9 @@ func main() {
 		gorush.LogError.Fatal(err)
 	}
 
-	//TODO: Check this part later to add Log Error for Huwei Push
+	if _, err = gorush.InitHMSClient(gorush.PushConf.Huawei.APIKey, gorush.PushConf.Huawei.APPId); err != nil {
+		gorush.LogError.Fatal(err)
+	}
 
 	var g errgroup.Group
 

--- a/main.go
+++ b/main.go
@@ -66,6 +66,10 @@ func main() {
 	flag.StringVar(&opts.Ios.Password, "password", "", "iOS certificate password for gorush")
 	flag.StringVar(&opts.Android.APIKey, "k", "", "Android api key configuration for gorush")
 	flag.StringVar(&opts.Android.APIKey, "apikey", "", "Android api key configuration for gorush")
+	flag.StringVar(&opts.Huawei.APIKey, "hk", "", "Huawei api key configuration for gorush")
+	flag.StringVar(&opts.Huawei.APIKey, "hmskey", "", "Huawei api key configuration for gorush")
+	flag.StringVar(&opts.Huawei.APPId, "hid", "", "HMS app id configuration for gorush")
+	flag.StringVar(&opts.Huawei.APPId, "hmsid", "", "HMS app id configuration for gorush")
 	flag.StringVar(&opts.Core.Address, "A", "", "address to bind")
 	flag.StringVar(&opts.Core.Address, "address", "", "address to bind")
 	flag.StringVar(&opts.Core.Port, "p", "", "port number for gorush")
@@ -79,6 +83,7 @@ func main() {
 	flag.StringVar(&message, "message", "", "notification message")
 	flag.StringVar(&title, "title", "", "notification title")
 	flag.BoolVar(&opts.Android.Enabled, "android", false, "send android notification")
+	flag.BoolVar(&opts.Huawei.Enabled, "huawei", false, "send huawei notification")
 	flag.BoolVar(&opts.Ios.Enabled, "ios", false, "send ios notification")
 	flag.BoolVar(&opts.Ios.Production, "production", false, "production mode in iOS")
 	flag.StringVar(&topic, "topic", "", "apns topic in iOS")
@@ -127,6 +132,14 @@ func main() {
 
 	if opts.Android.APIKey != "" {
 		gorush.PushConf.Android.APIKey = opts.Android.APIKey
+	}
+
+	if opts.Huawei.APIKey != "" {
+		gorush.PushConf.Huawei.APIKey = opts.Huawei.APIKey
+	}
+
+	if opts.Huawei.APPId != "" {
+		gorush.PushConf.Huawei.APPId = opts.Huawei.APPId
 	}
 
 	if opts.Stat.Engine != "" {
@@ -198,6 +211,40 @@ func main() {
 		}
 
 		gorush.PushToAndroid(req)
+
+		return
+	}
+
+	// send huawei notification
+	if opts.Huawei.Enabled {
+		gorush.PushConf.Huawei.Enabled = opts.Huawei.Enabled
+		req := gorush.PushNotification{
+			Platform: gorush.PlatFormHuawei,
+			Message:  message,
+			Title:    title,
+		}
+
+		// send message to single device
+		if token != "" {
+			req.Tokens = []string{token}
+		}
+
+		// send topic message
+		if topic != "" {
+			req.To = topic
+		}
+
+		err := gorush.CheckMessage(req)
+
+		if err != nil {
+			gorush.LogError.Fatal(err)
+		}
+
+		if err := gorush.InitAppStatus(); err != nil {
+			return
+		}
+
+		//gorush.PushToHuawei(req)
 
 		return
 	}
@@ -287,6 +334,8 @@ func main() {
 		gorush.LogError.Fatal(err)
 	}
 
+	//TODO: Check this part later to add Log Error for Huwei Push
+
 	var g errgroup.Group
 
 	// Run httpd server
@@ -345,8 +394,12 @@ iOS Options:
 Android Options:
     -k, --apikey <api_key>           Android API Key
     --android                        enabled android (default: false)
+Huawei Options:
+    -hk, --hmskey <hms_key>          HMS API Key
+    -hid, --hmsid <hms_id>			 HMS APP Id
+    --huawei                         enabled huawei (default: false)
 Common Options:
-    --topic <topic>                  iOS or Android topic message
+    --topic <topic>                  iOS, Android or Huawei topic message
     -h, --help                       Show this message
     -v, --version                    Show version
 `

--- a/storage/badger/badger.go
+++ b/storage/badger/badger.go
@@ -59,6 +59,8 @@ func (s *Storage) Reset() {
 	s.setBadger(storage.IosErrorKey, 0)
 	s.setBadger(storage.AndroidSuccessKey, 0)
 	s.setBadger(storage.AndroidErrorKey, 0)
+	s.setBadger(storage.HuaweiSuccessKey, 0)
+	s.setBadger(storage.HuaweiErrorKey, 0)
 }
 
 func (s *Storage) setBadger(key string, count int64) {
@@ -129,6 +131,18 @@ func (s *Storage) AddAndroidError(count int64) {
 	s.setBadger(storage.AndroidErrorKey, total)
 }
 
+// AddHuaweiSuccess record counts of success Huawei push notification.
+func (s *Storage) AddHuaweiSuccess(count int64) {
+	total := s.GetHuaweiSuccess() + count
+	s.setBadger(storage.HuaweiSuccessKey, total)
+}
+
+// AddHuaweiError record counts of error Huawei push notification.
+func (s *Storage) AddHuaweiError(count int64) {
+	total := s.GetHuaweiError() + count
+	s.setBadger(storage.HuaweiErrorKey, total)
+}
+
 // GetTotalCount show counts of all notification.
 func (s *Storage) GetTotalCount() int64 {
 	var count int64
@@ -165,6 +179,22 @@ func (s *Storage) GetAndroidSuccess() int64 {
 func (s *Storage) GetAndroidError() int64 {
 	var count int64
 	s.getBadger(storage.AndroidErrorKey, &count)
+
+	return count
+}
+
+// GetHuaweiSuccess show success counts of Huawei notification.
+func (s *Storage) GetHuaweiSuccess() int64 {
+	var count int64
+	s.getBadger(storage.HuaweiSuccessKey, &count)
+
+	return count
+}
+
+// GetHuaweiError show error counts of Huawei notification.
+func (s *Storage) GetHuaweiError() int64 {
+	var count int64
+	s.getBadger(storage.HuaweiErrorKey, &count)
 
 	return count
 }

--- a/storage/boltdb/boltdb.go
+++ b/storage/boltdb/boltdb.go
@@ -45,6 +45,8 @@ func (s *Storage) Reset() {
 	s.setBoltDB(storage.IosErrorKey, 0)
 	s.setBoltDB(storage.AndroidSuccessKey, 0)
 	s.setBoltDB(storage.AndroidErrorKey, 0)
+	s.setBoltDB(storage.HuaweiSuccessKey, 0)
+	s.setBoltDB(storage.HuaweiErrorKey, 0)
 }
 
 func (s *Storage) setBoltDB(key string, count int64) {
@@ -91,6 +93,18 @@ func (s *Storage) AddAndroidError(count int64) {
 	s.setBoltDB(storage.AndroidErrorKey, total)
 }
 
+// AddHuaweiSuccess record counts of success Huawei push notification.
+func (s *Storage) AddHuaweiSuccess(count int64) {
+	total := s.GetHuaweiSuccess() + count
+	s.setBoltDB(storage.HuaweiSuccessKey, total)
+}
+
+// AddHuaweiError record counts of error Huawei push notification.
+func (s *Storage) AddHuaweiError(count int64) {
+	total := s.GetHuaweiError() + count
+	s.setBoltDB(storage.HuaweiErrorKey, total)
+}
+
 // GetTotalCount show counts of all notification.
 func (s *Storage) GetTotalCount() int64 {
 	var count int64
@@ -127,6 +141,22 @@ func (s *Storage) GetAndroidSuccess() int64 {
 func (s *Storage) GetAndroidError() int64 {
 	var count int64
 	s.getBoltDB(storage.AndroidErrorKey, &count)
+
+	return count
+}
+
+// GetHuaweiSuccess show success counts of Huawei notification.
+func (s *Storage) GetHuaweiSuccess() int64 {
+	var count int64
+	s.getBoltDB(storage.HuaweiSuccessKey, &count)
+
+	return count
+}
+
+// GetHuaweiError show error counts of Huawei notification.
+func (s *Storage) GetHuaweiError() int64 {
+	var count int64
+	s.getBoltDB(storage.HuaweiErrorKey, &count)
 
 	return count
 }

--- a/storage/buntdb/buntdb.go
+++ b/storage/buntdb/buntdb.go
@@ -47,6 +47,8 @@ func (s *Storage) Reset() {
 	s.setBuntDB(storage.IosErrorKey, 0)
 	s.setBuntDB(storage.AndroidSuccessKey, 0)
 	s.setBuntDB(storage.AndroidErrorKey, 0)
+	s.setBuntDB(storage.HuaweiSuccessKey, 0)
+	s.setBuntDB(storage.HuaweiErrorKey, 0)
 }
 
 func (s *Storage) setBuntDB(key string, count int64) {
@@ -104,6 +106,18 @@ func (s *Storage) AddAndroidError(count int64) {
 	s.setBuntDB(storage.AndroidErrorKey, total)
 }
 
+// AddHuaweiSuccess record counts of success Huawei push notification.
+func (s *Storage) AddHuaweiSuccess(count int64) {
+	total := s.GetHuaweiSuccess() + count
+	s.setBuntDB(storage.HuaweiSuccessKey, total)
+}
+
+// AddHuaweiError record counts of error Huawei push notification.
+func (s *Storage) AddHuaweiError(count int64) {
+	total := s.GetHuaweiError() + count
+	s.setBuntDB(storage.HuaweiErrorKey, total)
+}
+
 // GetTotalCount show counts of all notification.
 func (s *Storage) GetTotalCount() int64 {
 	var count int64
@@ -140,6 +154,22 @@ func (s *Storage) GetAndroidSuccess() int64 {
 func (s *Storage) GetAndroidError() int64 {
 	var count int64
 	s.getBuntDB(storage.AndroidErrorKey, &count)
+
+	return count
+}
+
+// GetHuaweiSuccess show success counts of Huawei notification.
+func (s *Storage) GetHuaweiSuccess() int64 {
+	var count int64
+	s.getBuntDB(storage.HuaweiSuccessKey, &count)
+
+	return count
+}
+
+// GetHuaweiError show error counts of Huawei notification.
+func (s *Storage) GetHuaweiError() int64 {
+	var count int64
+	s.getBuntDB(storage.HuaweiErrorKey, &count)
 
 	return count
 }

--- a/storage/leveldb/leveldb.go
+++ b/storage/leveldb/leveldb.go
@@ -56,6 +56,8 @@ func (s *Storage) Reset() {
 	s.setLevelDB(storage.IosErrorKey, 0)
 	s.setLevelDB(storage.AndroidSuccessKey, 0)
 	s.setLevelDB(storage.AndroidErrorKey, 0)
+	s.setLevelDB(storage.HuaweiSuccessKey, 0)
+	s.setLevelDB(storage.HuaweiErrorKey, 0)
 }
 
 // AddTotalCount record push notification count.
@@ -86,6 +88,18 @@ func (s *Storage) AddAndroidSuccess(count int64) {
 func (s *Storage) AddAndroidError(count int64) {
 	total := s.GetAndroidError() + count
 	s.setLevelDB(storage.AndroidErrorKey, total)
+}
+
+// AddHuaweiSuccess record counts of success Huawei push notification.
+func (s *Storage) AddHuaweiSuccess(count int64) {
+	total := s.GetHuaweiSuccess() + count
+	s.setLevelDB(storage.HuaweiSuccessKey, total)
+}
+
+// AddHuaweiError record counts of error Huawei push notification.
+func (s *Storage) AddHuaweiError(count int64) {
+	total := s.GetHuaweiError() + count
+	s.setLevelDB(storage.HuaweiErrorKey, total)
 }
 
 // GetTotalCount show counts of all notification.
@@ -124,6 +138,22 @@ func (s *Storage) GetAndroidSuccess() int64 {
 func (s *Storage) GetAndroidError() int64 {
 	var count int64
 	s.getLevelDB(storage.AndroidErrorKey, &count)
+
+	return count
+}
+
+// GetHuaweiSuccess show success counts of Huawei notification.
+func (s *Storage) GetHuaweiSuccess() int64 {
+	var count int64
+	s.getLevelDB(storage.HuaweiSuccessKey, &count)
+
+	return count
+}
+
+// GetHuaweiError show error counts of Huawei notification.
+func (s *Storage) GetHuaweiError() int64 {
+	var count int64
+	s.getLevelDB(storage.HuaweiErrorKey, &count)
 
 	return count
 }

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -9,6 +9,7 @@ type statApp struct {
 	TotalCount int64         `json:"total_count"`
 	Ios        IosStatus     `json:"ios"`
 	Android    AndroidStatus `json:"android"`
+	Huawei     HuaweiStatus  `json:"huawei"`
 }
 
 // AndroidStatus is android structure
@@ -19,6 +20,12 @@ type AndroidStatus struct {
 
 // IosStatus is iOS structure
 type IosStatus struct {
+	PushSuccess int64 `json:"push_success"`
+	PushError   int64 `json:"push_error"`
+}
+
+// HuaweiStatus is android structure
+type HuaweiStatus struct {
 	PushSuccess int64 `json:"push_success"`
 	PushError   int64 `json:"push_error"`
 }
@@ -52,6 +59,8 @@ func (s *Storage) Reset() {
 	atomic.StoreInt64(&s.stat.Ios.PushError, 0)
 	atomic.StoreInt64(&s.stat.Android.PushSuccess, 0)
 	atomic.StoreInt64(&s.stat.Android.PushError, 0)
+	atomic.StoreInt64(&s.stat.Huawei.PushSuccess, 0)
+	atomic.StoreInt64(&s.stat.Huawei.PushError, 0)
 }
 
 // AddTotalCount record push notification count.
@@ -77,6 +86,16 @@ func (s *Storage) AddAndroidSuccess(count int64) {
 // AddAndroidError record counts of error Android push notification.
 func (s *Storage) AddAndroidError(count int64) {
 	atomic.AddInt64(&s.stat.Android.PushError, count)
+}
+
+// AddHuaweiSuccess record counts of success Huawei push notification.
+func (s *Storage) AddHuaweiSuccess(count int64) {
+	atomic.AddInt64(&s.stat.Huawei.PushSuccess, count)
+}
+
+// AddHuaweiError record counts of error Huawei push notification.
+func (s *Storage) AddHuaweiError(count int64) {
+	atomic.AddInt64(&s.stat.Huawei.PushError, count)
 }
 
 // GetTotalCount show counts of all notification.
@@ -110,6 +129,20 @@ func (s *Storage) GetAndroidSuccess() int64 {
 // GetAndroidError show error counts of Android notification.
 func (s *Storage) GetAndroidError() int64 {
 	count := atomic.LoadInt64(&s.stat.Android.PushError)
+
+	return count
+}
+
+// GetHuaweiSuccess show success counts of Huawei notification.
+func (s *Storage) GetHuaweiSuccess() int64 {
+	count := atomic.LoadInt64(&s.stat.Huawei.PushSuccess)
+
+	return count
+}
+
+// GetHuaweiError show error counts of Huawei notification.
+func (s *Storage) GetHuaweiError() int64 {
+	count := atomic.LoadInt64(&s.stat.Huawei.PushError)
 
 	return count
 }

--- a/storage/redis/redis.go
+++ b/storage/redis/redis.go
@@ -55,6 +55,8 @@ func (s *Storage) Reset() {
 	s.client.Set(storage.IosErrorKey, int64(0), 0)
 	s.client.Set(storage.AndroidSuccessKey, int64(0), 0)
 	s.client.Set(storage.AndroidErrorKey, int64(0), 0)
+	s.client.Set(storage.HuaweiSuccessKey, int64(0), 0)
+	s.client.Set(storage.HuaweiErrorKey, int64(0), 0)
 }
 
 // AddTotalCount record push notification count.
@@ -80,6 +82,16 @@ func (s *Storage) AddAndroidSuccess(count int64) {
 // AddAndroidError record counts of error Android push notification.
 func (s *Storage) AddAndroidError(count int64) {
 	s.client.IncrBy(storage.AndroidErrorKey, count)
+}
+
+// AddHuaweiSuccess record counts of success Android push notification.
+func (s *Storage) AddHuaweiSuccess(count int64) {
+	s.client.IncrBy(storage.HuaweiSuccessKey, count)
+}
+
+// AddHuaweiError record counts of error Android push notification.
+func (s *Storage) AddHuaweiError(count int64) {
+	s.client.IncrBy(storage.HuaweiErrorKey, count)
 }
 
 // GetTotalCount show counts of all notification.
@@ -121,3 +133,20 @@ func (s *Storage) GetAndroidError() int64 {
 
 	return count
 }
+
+// GetHuaweiSuccess show success counts of Huawei notification.
+func (s *Storage) GetHuaweiSuccess() int64 {
+	var count int64
+	s.getInt64(storage.HuaweiSuccessKey, &count)
+
+	return count
+}
+
+// GetHuaweiError show error counts of Huawei notification.
+func (s *Storage) GetHuaweiError() int64 {
+	var count int64
+	s.getInt64(storage.HuaweiErrorKey, &count)
+
+	return count
+}
+

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -15,6 +15,12 @@ const (
 
 	// AndroidErrorKey is key name for android error count of storage
 	AndroidErrorKey = "gorush-android-error-count"
+
+	// HuaweiSuccessKey is key name for huawei success count of storage
+	HuaweiSuccessKey = "gorush-huawei-success-count"
+
+	// HuaweiErrorKey is key name for huawei error count of storage
+	HuaweiErrorKey = "gorush-huawei-error-count"
 )
 
 // Storage interface
@@ -26,10 +32,14 @@ type Storage interface {
 	AddIosError(int64)
 	AddAndroidSuccess(int64)
 	AddAndroidError(int64)
+	AddHuaweiSuccess(int64)
+	AddHuaweiError(int64)
 	GetTotalCount() int64
 	GetIosSuccess() int64
 	GetIosError() int64
 	GetAndroidSuccess() int64
 	GetAndroidError() int64
+	GetHuaweiSuccess() int64
+	GetHuaweiError() int64
 	Close() error
 }


### PR DESCRIPTION
This pull request includes Huawei Mobile Service support for GoRush. #426 

1. New Platform type is created PlatFormHuawei (as Platform:3)
2. Add config parameters for HMS: APP_ID and API_KEY which gets from Huawei Developer Console
2. Add https://github.com/msalihkarakasli/go-hms-push library to manage HMS Push Service API.
3. Add **notification_hms** script to send notification via Huawei Mobile Services
4. HMS does not provide information about the success and failure of each token in the request so I preferred to update statistics based on request count.
5. Update all storage options for HMS push notifications
6. Update READMEto explain clear flow usage of HMS with gorush.